### PR TITLE
fix(auth): remove double password hashing on registration

### DIFF
--- a/src/module/auth/auth.service.ts
+++ b/src/module/auth/auth.service.ts
@@ -25,12 +25,7 @@ export class AuthService {
       throw new ConflictException('Email already exists');
     }
 
-    const hashedPassword = await bcrypt.hash(registerDto.password, 10);
-
-    const user = await this.usersService.create({
-      ...registerDto,
-      password: hashedPassword,
-    });
+    const user = await this.usersService.create(registerDto);
 
     const payload = { sub: user.id, email: user.email, role: user.role };
     const access_token = this.jwtService.sign(payload);


### PR DESCRIPTION
Your password was being hashed twice during the registration process: once in the `AuthService` and then again in the `UsersService`. This caused login attempts to always fail because the password comparison was against a double-hashed password.

This change removes the password hashing from the `AuthService`'s `register` method, making the `UsersService` the single source of truth for password hashing. This ensures that passwords are only hashed once, allowing you to log in successfully.