### PR TITLE
fix(auth): Correct role checking in RolesGuard

### DIFF
--- a/src/common/guards/roles.guard.ts
+++ b/src/common/guards/roles.guard.ts
@@ -19,10 +19,10 @@ export class RolesGuard implements CanActivate {
 
     const { user } = context.switchToHttp().getRequest();
 
-    if (!user || !user.roles) {
+    if (!user || !user.role) {
       return false;
     }
 
-    return requiredRoles.some((role) => user.roles?.includes(role));
+    return requiredRoles.includes(user.role);
   }
 }


### PR DESCRIPTION
The `RolesGuard` was incorrectly checking for `user.roles` (plural) on the user object, which does not exist. The correct property is `user.role` (singular), as defined in the `User` entity.

This commit corrects the logic in `RolesGuard` to check `user.role` against the required roles. This resolves the issue where all endpoints protected by this guard were inaccessible.